### PR TITLE
feat(api): add /uptime endpoint (fixes #4)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import {
 } from "./store.js";
 import { healthCheck } from "./health.js";
 import { getStats } from "./stats.js";
+import { getUptime } from "./uptime.js";
 
 export const app: Express = express();
 app.use(express.json());
@@ -17,6 +18,9 @@ app.get("/health", healthCheck);
 
 // Stats
 app.get("/stats", getStats);
+
+// Uptime
+app.get("/uptime", getUptime);
 
 // List all todos
 app.get("/todos", (_req, res) => {

--- a/src/uptime.test.ts
+++ b/src/uptime.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { getUptime, STARTED_AT } from "./uptime.js";
+
+function createApp() {
+  const app = express();
+  app.get("/uptime", getUptime);
+  return app;
+}
+
+describe("GET /uptime", () => {
+  it("returns uptime_seconds as a non-negative number", async () => {
+    const res = await request(createApp()).get("/uptime");
+    expect(res.status).toBe(200);
+    expect(typeof res.body.uptime_seconds).toBe("number");
+    expect(res.body.uptime_seconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns uptime_human in Xd Xh Xm Xs format", async () => {
+    const res = await request(createApp()).get("/uptime");
+    expect(res.body.uptime_human).toMatch(/^\d+d \d+h \d+m \d+s$/);
+  });
+
+  it("returns started_at as a valid ISO 8601 timestamp", async () => {
+    const res = await request(createApp()).get("/uptime");
+    expect(typeof res.body.started_at).toBe("string");
+    const parsed = new Date(res.body.started_at);
+    expect(parsed.toISOString()).toBe(res.body.started_at);
+    expect(parsed.getTime()).toBe(STARTED_AT.getTime());
+  });
+
+  it("returns all required fields", async () => {
+    const res = await request(createApp()).get("/uptime");
+    expect(res.body).toHaveProperty("uptime_seconds");
+    expect(res.body).toHaveProperty("uptime_human");
+    expect(res.body).toHaveProperty("started_at");
+  });
+});

--- a/src/uptime.ts
+++ b/src/uptime.ts
@@ -1,0 +1,20 @@
+import type { Request, Response } from "express";
+
+export const STARTED_AT = new Date();
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  return `${d}d ${h}h ${m}m ${s}s`;
+}
+
+export function getUptime(_req: Request, res: Response): void {
+  const uptimeSeconds = Math.floor((Date.now() - STARTED_AT.getTime()) / 1000);
+  res.json({
+    uptime_seconds: uptimeSeconds,
+    uptime_human: formatUptime(uptimeSeconds),
+    started_at: STARTED_AT.toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary
- Added `GET /uptime` endpoint returning `uptime_seconds`, `uptime_human`, and `started_at`
- Created `src/uptime.ts` with module-level `STARTED_AT` constant and `formatUptime` helper
- Registered route in `src/app.ts`
- Added `src/uptime.test.ts` with 4 tests covering all fields and formats

## Test plan
- [x] Tests pass locally (`pnpm test` — 33 tests, 0 failures)
- [x] Quality gate passes (`pnpm check`)

Fixes #4