### PR TITLE
feat(api): add /version endpoint (fixes #3)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,12 +8,16 @@ import {
 } from "./store.js";
 import { healthCheck } from "./health.js";
 import { getStats } from "./stats.js";
+import { getVersion } from "./version.js";
 
 export const app: Express = express();
 app.use(express.json());
 
 // Health check
 app.get("/health", healthCheck);
+
+// Version
+app.get("/version", getVersion);
 
 // Stats
 app.get("/stats", getStats);

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { getVersion } from "./version.js";
+
+function createApp() {
+  const app = express();
+  app.get("/version", getVersion);
+  return app;
+}
+
+describe("GET /version", () => {
+  it("returns name and version from package.json", async () => {
+    const res = await request(createApp()).get("/version");
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("multi-agent-factory");
+    expect(res.body.version).toBe("0.1.0");
+  });
+
+  it("includes node version", async () => {
+    const res = await request(createApp()).get("/version");
+    expect(res.body).toHaveProperty("node");
+    expect(typeof res.body.node).toBe("string");
+    expect(res.body.node).toBe(process.version);
+  });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,20 @@
+import { createRequire } from "node:module";
+import type { Request, Response } from "express";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { name: string; version: string };
+
+export interface VersionInfo {
+  name: string;
+  version: string;
+  node: string;
+}
+
+export function getVersion(_req: Request, res: Response): void {
+  const info: VersionInfo = {
+    name: pkg.name,
+    version: pkg.version,
+    node: process.version,
+  };
+  res.json(info);
+}


### PR DESCRIPTION
## Summary
- Add `GET /version` endpoint returning `{ name, version, node }` from package.json
- Create `src/version.ts` with route handler using `createRequire` to load package.json
- Register route in `src/app.ts`
- Write tests in `src/version.test.ts`

## Test plan
- [x] Tests pass locally (31/31)
- [x] Quality gate passes (`pnpm check`)

Fixes #3