### PR TITLE
feat(web): add todo list page (fixes #12)

### DIFF
--- a/public/todo.html
+++ b/public/todo.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Todo List</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f0f2f5;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      padding: 2rem 1rem;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 540px;
+    }
+
+    header {
+      background: linear-gradient(135deg, #6366f1, #8b5cf6);
+      border-radius: 16px 16px 0 0;
+      padding: 1.75rem 1.5rem 1.25rem;
+      color: #fff;
+    }
+
+    header h1 {
+      font-size: 1.75rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    header p {
+      margin-top: 0.25rem;
+      font-size: 0.9rem;
+      opacity: 0.85;
+    }
+
+    .add-form {
+      background: #fff;
+      padding: 1.25rem 1.5rem;
+      display: flex;
+      gap: 0.75rem;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .add-form input {
+      flex: 1;
+      border: 1.5px solid #d1d5db;
+      border-radius: 8px;
+      padding: 0.6rem 0.85rem;
+      font-size: 0.95rem;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+
+    .add-form input:focus { border-color: #6366f1; }
+
+    .add-form button {
+      background: #6366f1;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      padding: 0.6rem 1.1rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+      white-space: nowrap;
+    }
+
+    .add-form button:hover { background: #4f46e5; }
+
+    .todo-list {
+      background: #fff;
+      border-radius: 0 0 16px 16px;
+      overflow: hidden;
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 3rem 1rem;
+      color: #9ca3af;
+      font-size: 0.95rem;
+    }
+
+    .todo-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.85rem 1.5rem;
+      border-bottom: 1px solid #f3f4f6;
+      transition: background 0.1s;
+    }
+
+    .todo-item:last-child { border-bottom: none; }
+    .todo-item:hover { background: #fafafa; }
+
+    /* Custom checkbox */
+    .checkbox {
+      width: 20px;
+      height: 20px;
+      border: 2px solid #d1d5db;
+      border-radius: 50%;
+      cursor: pointer;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: border-color 0.15s, background 0.15s;
+    }
+
+    .todo-item.done .checkbox {
+      background: #6366f1;
+      border-color: #6366f1;
+    }
+
+    .checkbox::after {
+      content: '';
+      display: none;
+      width: 5px;
+      height: 9px;
+      border: 2px solid #fff;
+      border-top: none;
+      border-left: none;
+      transform: rotate(45deg) translate(-1px, -1px);
+    }
+
+    .todo-item.done .checkbox::after { display: block; }
+
+    .todo-text {
+      flex: 1;
+      font-size: 0.95rem;
+      color: #374151;
+      cursor: pointer;
+      transition: color 0.15s;
+      word-break: break-word;
+    }
+
+    .todo-item.done .todo-text {
+      color: #9ca3af;
+      text-decoration: line-through;
+    }
+
+    .delete-btn {
+      background: none;
+      border: none;
+      color: #d1d5db;
+      font-size: 1.1rem;
+      cursor: pointer;
+      padding: 0.25rem;
+      border-radius: 4px;
+      line-height: 1;
+      transition: color 0.15s;
+      flex-shrink: 0;
+    }
+
+    .delete-btn:hover { color: #ef4444; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Todo List</h1>
+      <p id="count">0 items remaining</p>
+    </header>
+
+    <form class="add-form" id="add-form">
+      <input
+        type="text"
+        id="new-todo"
+        placeholder="Add a new todo…"
+        autocomplete="off"
+        aria-label="New todo text"
+      >
+      <button type="submit">Add</button>
+    </form>
+
+    <div class="todo-list" id="todo-list" role="list" aria-label="Todo items">
+      <p class="empty-state" id="empty-state">No todos yet. Add one above!</p>
+    </div>
+  </div>
+
+  <script>
+    const STORAGE_KEY = 'todos-v1';
+
+    // Load from localStorage
+    let todos = [];
+    try {
+      todos = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    } catch {
+      todos = [];
+    }
+
+    function save() {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(todos));
+    }
+
+    function render() {
+      const list = document.getElementById('todo-list');
+      const empty = document.getElementById('empty-state');
+      const count = document.getElementById('count');
+
+      const remaining = todos.filter(t => !t.done).length;
+      count.textContent = `${remaining} item${remaining !== 1 ? 's' : ''} remaining`;
+
+      if (todos.length === 0) {
+        empty.style.display = '';
+        // Remove any existing items
+        list.querySelectorAll('.todo-item').forEach(el => el.remove());
+        return;
+      }
+
+      empty.style.display = 'none';
+
+      // Rebuild list
+      list.querySelectorAll('.todo-item').forEach(el => el.remove());
+
+      todos.forEach(todo => {
+        const item = document.createElement('div');
+        item.className = `todo-item${todo.done ? ' done' : ''}`;
+        item.setAttribute('role', 'listitem');
+
+        const checkbox = document.createElement('div');
+        checkbox.className = 'checkbox';
+        checkbox.setAttribute('role', 'checkbox');
+        checkbox.setAttribute('aria-checked', String(todo.done));
+        checkbox.setAttribute('aria-label', todo.done ? 'Mark incomplete' : 'Mark complete');
+        checkbox.tabIndex = 0;
+
+        const text = document.createElement('span');
+        text.className = 'todo-text';
+        text.textContent = todo.text;
+
+        const del = document.createElement('button');
+        del.className = 'delete-btn';
+        del.textContent = '×';
+        del.setAttribute('aria-label', `Delete "${todo.text}"`);
+
+        // Toggle complete
+        function toggle() {
+          todo.done = !todo.done;
+          save();
+          render();
+        }
+        checkbox.addEventListener('click', toggle);
+        checkbox.addEventListener('keydown', e => {
+          if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); toggle(); }
+        });
+        text.addEventListener('click', toggle);
+
+        // Delete
+        del.addEventListener('click', () => {
+          todos = todos.filter(t => t.id !== todo.id);
+          save();
+          render();
+        });
+
+        item.appendChild(checkbox);
+        item.appendChild(text);
+        item.appendChild(del);
+        list.appendChild(item);
+      });
+    }
+
+    // Add new todo
+    document.getElementById('add-form').addEventListener('submit', e => {
+      e.preventDefault();
+      const input = document.getElementById('new-todo');
+      const text = input.value.trim();
+      if (!text) return;
+      todos.push({ id: Date.now(), text, done: false });
+      save();
+      render();
+      input.value = '';
+      input.focus();
+    });
+
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Created `public/todo.html` — a standalone, self-contained todo list application
- No external dependencies; all CSS and JS embedded in the HTML file
- Todos persist across sessions via localStorage

## Features
- Add new todo items via form input
- Toggle complete/incomplete by clicking the checkbox or todo text (strikethrough on complete)
- Delete items with the × button
- Live count of remaining incomplete items
- Empty state shown when no todos exist
- Accessible: ARIA roles/labels, keyboard navigation (Space/Enter to toggle)

## Test plan
- [x] Quality gate passes (`pnpm check`)
- [x] `public/todo.html` is valid HTML5 with no external dependencies
- [x] Add, toggle, and delete work correctly
- [x] Data persists via localStorage across page reloads

Fixes #12