### PR TITLE
feat(web): add dark/light theme toggle page (fixes #10)

### DIFF
--- a/public/theme-toggle.html
+++ b/public/theme-toggle.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Theme Toggle</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      :root {
+        --bg: #f5f5f5;
+        --surface: #ffffff;
+        --text-primary: #1a1a1a;
+        --text-secondary: #555555;
+        --border: #e0e0e0;
+        --btn-bg: #1a1a1a;
+        --btn-text: #ffffff;
+        --shadow: rgba(0, 0, 0, 0.08);
+        --transition: 0.3s ease;
+      }
+
+      [data-theme="dark"] {
+        --bg: #121212;
+        --surface: #1e1e1e;
+        --text-primary: #f0f0f0;
+        --text-secondary: #aaaaaa;
+        --border: #2e2e2e;
+        --btn-bg: #f0f0f0;
+        --btn-text: #121212;
+        --shadow: rgba(0, 0, 0, 0.4);
+      }
+
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background-color: var(--bg);
+        color: var(--text-primary);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        transition:
+          background-color var(--transition),
+          color var(--transition);
+      }
+
+      header {
+        position: fixed;
+        top: 0;
+        right: 0;
+        padding: 1rem;
+      }
+
+      .toggle-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1.25rem;
+        background-color: var(--btn-bg);
+        color: var(--btn-text);
+        border: none;
+        border-radius: 999px;
+        font-size: 0.875rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition:
+          background-color var(--transition),
+          color var(--transition),
+          transform 0.15s ease;
+      }
+
+      .toggle-btn:hover {
+        transform: scale(1.05);
+      }
+
+      .toggle-btn:active {
+        transform: scale(0.97);
+      }
+
+      .toggle-btn .icon {
+        font-size: 1rem;
+        line-height: 1;
+      }
+
+      main {
+        width: 100%;
+        max-width: 640px;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      h1 {
+        font-size: 2rem;
+        font-weight: 700;
+        line-height: 1.2;
+        transition: color var(--transition);
+      }
+
+      p {
+        color: var(--text-secondary);
+        line-height: 1.7;
+        transition: color var(--transition);
+      }
+
+      .card {
+        background-color: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1.5rem;
+        box-shadow: 0 2px 8px var(--shadow);
+        transition:
+          background-color var(--transition),
+          border-color var(--transition),
+          box-shadow var(--transition);
+      }
+
+      .card h2 {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        transition: color var(--transition);
+      }
+
+      .card p {
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <button class="toggle-btn" id="themeToggle" aria-label="Toggle theme">
+        <span class="icon" id="themeIcon">🌙</span>
+        <span id="themeLabel">Dark mode</span>
+      </button>
+    </header>
+
+    <main>
+      <h1>Theme Toggle Demo</h1>
+      <p>
+        This page demonstrates a smooth dark/light theme toggle with preference
+        persistence via <code>localStorage</code>. Click the button in the top
+        right to switch themes.
+      </p>
+
+      <div class="card">
+        <h2>How it works</h2>
+        <p>
+          The theme is stored in <code>localStorage</code> so your preference
+          persists across page reloads. CSS custom properties drive all colors,
+          and a CSS transition on each property ensures smooth switching.
+        </p>
+      </div>
+
+      <div class="card">
+        <h2>No dependencies</h2>
+        <p>
+          This page is a single self-contained HTML file with embedded CSS and
+          JavaScript — no frameworks, no external libraries, no network requests.
+        </p>
+      </div>
+    </main>
+
+    <script>
+      const STORAGE_KEY = "theme-preference";
+      const html = document.documentElement;
+      const btn = document.getElementById("themeToggle");
+      const icon = document.getElementById("themeIcon");
+      const label = document.getElementById("themeLabel");
+
+      function isDark() {
+        return html.getAttribute("data-theme") === "dark";
+      }
+
+      function applyTheme(dark) {
+        html.setAttribute("data-theme", dark ? "dark" : "light");
+        icon.textContent = dark ? "☀️" : "🌙";
+        label.textContent = dark ? "Light mode" : "Dark mode";
+      }
+
+      // Initialise from saved preference, falling back to system preference
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved !== null) {
+        applyTheme(saved === "dark");
+      } else {
+        applyTheme(window.matchMedia("(prefers-color-scheme: dark)").matches);
+      }
+
+      btn.addEventListener("click", () => {
+        const next = !isDark();
+        applyTheme(next);
+        localStorage.setItem(STORAGE_KEY, next ? "dark" : "light");
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Created `public/theme-toggle.html` — a single self-contained HTML file with embedded CSS and JavaScript
- Dark/light theme toggle button in top-right corner with smooth 0.3s CSS transitions
- Theme preference persisted to `localStorage` with `theme-preference` key
- Falls back to `prefers-color-scheme` system setting when no preference is saved
- No external dependencies — pure HTML, CSS, and vanilla JavaScript

## Test plan
- [x] `public/theme-toggle.html` exists and is valid HTML5
- [x] Toggle button switches between dark and light themes
- [x] Theme persists across page reload via localStorage
- [x] Smooth CSS transitions on all themed elements (0.3s ease)
- [x] No external dependencies

Fixes #10