### PR TITLE
feat(public): add markdown preview page (fixes #23)

### DIFF
--- a/public/markdown-preview.html
+++ b/public/markdown-preview.html
@@ -1,0 +1,597 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Markdown Preview</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      min-height: 100vh;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      background: #16213e;
+      border-bottom: 1px solid #0f3460;
+      padding: 0.75rem 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    header h1 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #e94560;
+      letter-spacing: -0.3px;
+      flex-shrink: 0;
+    }
+
+    .toolbar {
+      display: flex;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+    }
+
+    .toolbar button {
+      background: #0f3460;
+      color: #e0e0e0;
+      border: 1px solid #1a4a7a;
+      border-radius: 4px;
+      padding: 0.3rem 0.6rem;
+      font-size: 0.78rem;
+      font-family: monospace;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+      white-space: nowrap;
+    }
+
+    .toolbar button:hover {
+      background: #1a5a9a;
+      border-color: #2a6aaa;
+    }
+
+    .toolbar button:active {
+      background: #e94560;
+      border-color: #e94560;
+      color: #fff;
+    }
+
+    .panes {
+      flex: 1;
+      display: flex;
+      overflow: hidden;
+    }
+
+    .pane {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+
+    .pane-label {
+      background: #16213e;
+      color: #888;
+      font-size: 0.72rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 0.35rem 1rem;
+      border-bottom: 1px solid #0f3460;
+    }
+
+    .divider {
+      width: 4px;
+      background: #0f3460;
+      cursor: col-resize;
+      flex-shrink: 0;
+      transition: background 0.15s;
+    }
+
+    .divider:hover, .divider.dragging {
+      background: #e94560;
+    }
+
+    #editor {
+      flex: 1;
+      resize: none;
+      background: #0d0d1a;
+      color: #d0d0e0;
+      border: none;
+      outline: none;
+      padding: 1.25rem;
+      font-family: 'Courier New', Courier, monospace;
+      font-size: 0.9rem;
+      line-height: 1.6;
+      tab-size: 2;
+    }
+
+    #preview {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.25rem 1.5rem;
+      background: #111122;
+      line-height: 1.7;
+    }
+
+    /* Markdown rendered styles */
+    #preview h1, #preview h2, #preview h3,
+    #preview h4, #preview h5, #preview h6 {
+      color: #fff;
+      margin: 1.2em 0 0.5em;
+      line-height: 1.3;
+      font-weight: 700;
+    }
+
+    #preview h1 { font-size: 2em; border-bottom: 1px solid #0f3460; padding-bottom: 0.3em; }
+    #preview h2 { font-size: 1.5em; border-bottom: 1px solid #0f3460; padding-bottom: 0.2em; }
+    #preview h3 { font-size: 1.25em; }
+    #preview h4 { font-size: 1.05em; }
+    #preview h5 { font-size: 0.95em; }
+    #preview h6 { font-size: 0.85em; color: #aaa; }
+
+    #preview p { margin: 0.75em 0; }
+
+    #preview strong { color: #fff; font-weight: 700; }
+    #preview em { color: #c8c8e8; font-style: italic; }
+    #preview s { color: #888; text-decoration: line-through; }
+
+    #preview a { color: #4ea8de; text-decoration: none; }
+    #preview a:hover { text-decoration: underline; }
+
+    #preview ul, #preview ol {
+      margin: 0.6em 0 0.6em 1.5em;
+    }
+
+    #preview li { margin: 0.25em 0; }
+
+    #preview blockquote {
+      border-left: 3px solid #e94560;
+      margin: 0.75em 0;
+      padding: 0.4em 1em;
+      background: #16213e;
+      border-radius: 0 4px 4px 0;
+      color: #bbb;
+    }
+
+    #preview code {
+      font-family: 'Courier New', Courier, monospace;
+      font-size: 0.88em;
+      background: #1e1e3a;
+      color: #e94560;
+      padding: 0.15em 0.4em;
+      border-radius: 3px;
+    }
+
+    #preview pre {
+      background: #0d0d1a;
+      border: 1px solid #0f3460;
+      border-radius: 6px;
+      padding: 1em;
+      overflow-x: auto;
+      margin: 0.75em 0;
+    }
+
+    #preview pre code {
+      background: none;
+      color: #a8d8a8;
+      padding: 0;
+      font-size: 0.88em;
+    }
+
+    #preview hr {
+      border: none;
+      border-top: 1px solid #0f3460;
+      margin: 1.5em 0;
+    }
+
+    #preview table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 0.75em 0;
+      font-size: 0.9em;
+    }
+
+    #preview th, #preview td {
+      border: 1px solid #0f3460;
+      padding: 0.5em 0.75em;
+      text-align: left;
+    }
+
+    #preview th {
+      background: #16213e;
+      color: #fff;
+      font-weight: 700;
+    }
+
+    #preview tr:nth-child(even) td {
+      background: #111133;
+    }
+
+    #preview img {
+      max-width: 100%;
+      border-radius: 4px;
+    }
+
+    /* Responsive */
+    @media (max-width: 640px) {
+      .panes { flex-direction: column; }
+      .divider { width: 100%; height: 4px; cursor: row-resize; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Markdown Preview</h1>
+  <div class="toolbar">
+    <button data-wrap="**" data-wrap-end="**" title="Bold">**Bold**</button>
+    <button data-wrap="*" data-wrap-end="*" title="Italic">*Italic*</button>
+    <button data-wrap="~~" data-wrap-end="~~" title="Strikethrough">~~Strike~~</button>
+    <button data-wrap="`" data-wrap-end="`" title="Inline code">`Code`</button>
+    <button data-prefix="# " title="H1">H1</button>
+    <button data-prefix="## " title="H2">H2</button>
+    <button data-prefix="### " title="H3">H3</button>
+    <button data-prefix="- " title="Unordered list">• List</button>
+    <button data-prefix="1. " title="Ordered list">1. List</button>
+    <button data-prefix="> " title="Blockquote">&gt; Quote</button>
+    <button data-block="```\n" data-block-end="\n```" title="Code block">```Block```</button>
+    <button data-snippet="[text](url)" title="Link">[Link]</button>
+    <button data-snippet="---" title="Horizontal rule">---</button>
+    <button id="clearBtn" title="Clear editor">Clear</button>
+  </div>
+</header>
+
+<div class="panes">
+  <div class="pane">
+    <div class="pane-label">Markdown Input</div>
+    <textarea id="editor" spellcheck="false" placeholder="Type markdown here…"></textarea>
+  </div>
+  <div class="divider" id="divider"></div>
+  <div class="pane">
+    <div class="pane-label">Preview</div>
+    <div id="preview"></div>
+  </div>
+</div>
+
+<script>
+  // ── Markdown Parser (regex-based, no external deps) ──────────────────────
+
+  function escapeHtml(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function parseInline(text) {
+    // Preserve existing HTML entities
+    let out = text;
+
+    // Escape HTML first (but not inside already-processed spans)
+    out = escapeHtml(out);
+
+    // Images before links
+    out = out.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">');
+
+    // Links
+    out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+
+    // Bold + italic
+    out = out.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
+
+    // Bold
+    out = out.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    out = out.replace(/__(.+?)__/g, '<strong>$1</strong>');
+
+    // Italic
+    out = out.replace(/\*(.+?)\*/g, '<em>$1</em>');
+    out = out.replace(/_(.+?)_/g, '<em>$1</em>');
+
+    // Strikethrough
+    out = out.replace(/~~(.+?)~~/g, '<s>$1</s>');
+
+    // Inline code
+    out = out.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+    return out;
+  }
+
+  function parseMarkdown(md) {
+    const lines = md.split('\n');
+    const html = [];
+    let i = 0;
+
+    while (i < lines.length) {
+      const line = lines[i];
+
+      // Fenced code blocks
+      if (/^```/.test(line)) {
+        const lang = line.slice(3).trim();
+        const codeLines = [];
+        i++;
+        while (i < lines.length && !/^```/.test(lines[i])) {
+          codeLines.push(escapeHtml(lines[i]));
+          i++;
+        }
+        html.push(`<pre><code${lang ? ` class="language-${lang}"` : ''}>${codeLines.join('\n')}</code></pre>`);
+        i++;
+        continue;
+      }
+
+      // Headings
+      const hMatch = line.match(/^(#{1,6})\s+(.+)/);
+      if (hMatch) {
+        const level = hMatch[1].length;
+        html.push(`<h${level}>${parseInline(hMatch[2])}</h${level}>`);
+        i++;
+        continue;
+      }
+
+      // Horizontal rule
+      if (/^(\-{3,}|\*{3,}|_{3,})$/.test(line.trim())) {
+        html.push('<hr>');
+        i++;
+        continue;
+      }
+
+      // Blockquote
+      if (/^>\s?/.test(line)) {
+        const quoteLines = [];
+        while (i < lines.length && /^>\s?/.test(lines[i])) {
+          quoteLines.push(lines[i].replace(/^>\s?/, ''));
+          i++;
+        }
+        html.push(`<blockquote>${parseMarkdown(quoteLines.join('\n'))}</blockquote>`);
+        continue;
+      }
+
+      // Unordered list
+      if (/^[\-\*\+]\s/.test(line)) {
+        const items = [];
+        while (i < lines.length && /^[\-\*\+]\s/.test(lines[i])) {
+          items.push(`<li>${parseInline(lines[i].replace(/^[\-\*\+]\s/, ''))}</li>`);
+          i++;
+        }
+        html.push(`<ul>${items.join('')}</ul>`);
+        continue;
+      }
+
+      // Ordered list
+      if (/^\d+\.\s/.test(line)) {
+        const items = [];
+        while (i < lines.length && /^\d+\.\s/.test(lines[i])) {
+          items.push(`<li>${parseInline(lines[i].replace(/^\d+\.\s/, ''))}</li>`);
+          i++;
+        }
+        html.push(`<ol>${items.join('')}</ol>`);
+        continue;
+      }
+
+      // Table
+      if (/\|/.test(line) && i + 1 < lines.length && /^\|?\s*:?-+:?\s*\|/.test(lines[i + 1])) {
+        const headerCells = line.split('|').filter(c => c.trim() !== '');
+        const ths = headerCells.map(c => `<th>${parseInline(c.trim())}</th>`).join('');
+        i += 2; // skip header + separator
+        const rows = [];
+        while (i < lines.length && /\|/.test(lines[i])) {
+          const cells = lines[i].split('|').filter(c => c.trim() !== '');
+          const tds = cells.map(c => `<td>${parseInline(c.trim())}</td>`).join('');
+          rows.push(`<tr>${tds}</tr>`);
+          i++;
+        }
+        html.push(`<table><thead><tr>${ths}</tr></thead><tbody>${rows.join('')}</tbody></table>`);
+        continue;
+      }
+
+      // Blank line
+      if (line.trim() === '') {
+        i++;
+        continue;
+      }
+
+      // Paragraph — collect consecutive non-blank, non-special lines
+      const paraLines = [];
+      while (
+        i < lines.length &&
+        lines[i].trim() !== '' &&
+        !/^#{1,6}\s/.test(lines[i]) &&
+        !/^[\-\*\+]\s/.test(lines[i]) &&
+        !/^\d+\.\s/.test(lines[i]) &&
+        !/^>\s?/.test(lines[i]) &&
+        !/^```/.test(lines[i]) &&
+        !/^(\-{3,}|\*{3,}|_{3,})$/.test(lines[i].trim())
+      ) {
+        paraLines.push(lines[i]);
+        i++;
+      }
+      if (paraLines.length > 0) {
+        html.push(`<p>${parseInline(paraLines.join('<br>'))}</p>`);
+      }
+    }
+
+    return html.join('\n');
+  }
+
+  // ── Editor → Preview wiring ──────────────────────────────────────────────
+
+  const editor = document.getElementById('editor');
+  const preview = document.getElementById('preview');
+
+  function render() {
+    preview.innerHTML = parseMarkdown(editor.value);
+  }
+
+  editor.addEventListener('input', render);
+
+  // ── Default content ──────────────────────────────────────────────────────
+
+  editor.value = `# Markdown Preview
+
+Welcome to the **live markdown editor**! Type on the left and see the result on the right.
+
+## Features
+
+- Live preview as you type
+- Basic markdown: *italic*, **bold**, ~~strikethrough~~
+- Inline \`code\` and fenced code blocks
+- Ordered and unordered lists
+- Blockquotes
+- Tables
+- Links and images
+- Horizontal rules
+- Toolbar with quick-insert buttons
+
+## Code Example
+
+\`\`\`js
+function greet(name) {
+  return \`Hello, \${name}!\`;
+}
+console.log(greet('World'));
+\`\`\`
+
+## Table Example
+
+| Feature       | Supported |
+|---------------|-----------|
+| Headers       | ✓         |
+| Bold / Italic | ✓         |
+| Code blocks   | ✓         |
+| Tables        | ✓         |
+| Links         | ✓         |
+
+## Blockquote
+
+> "The best way to predict the future is to implement it."
+
+---
+
+[GitHub](https://github.com) | *No external libraries required.*
+`;
+
+  render();
+
+  // ── Toolbar button actions ───────────────────────────────────────────────
+
+  document.querySelectorAll('.toolbar button[data-wrap]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const wrap = btn.dataset.wrap;
+      const wrapEnd = btn.dataset.wrapEnd;
+      const start = editor.selectionStart;
+      const end = editor.selectionEnd;
+      const selected = editor.value.slice(start, end) || 'text';
+      const before = editor.value.slice(0, start);
+      const after = editor.value.slice(end);
+      editor.value = before + wrap + selected + wrapEnd + after;
+      editor.selectionStart = start + wrap.length;
+      editor.selectionEnd = start + wrap.length + selected.length;
+      editor.focus();
+      render();
+    });
+  });
+
+  document.querySelectorAll('.toolbar button[data-prefix]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const prefix = btn.dataset.prefix;
+      const start = editor.selectionStart;
+      const lineStart = editor.value.lastIndexOf('\n', start - 1) + 1;
+      const before = editor.value.slice(0, lineStart);
+      const after = editor.value.slice(lineStart);
+      editor.value = before + prefix + after;
+      editor.selectionStart = editor.selectionEnd = lineStart + prefix.length;
+      editor.focus();
+      render();
+    });
+  });
+
+  document.querySelectorAll('.toolbar button[data-block]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const blockStart = btn.dataset.block;
+      const blockEnd = btn.dataset.blockEnd;
+      const start = editor.selectionStart;
+      const end = editor.selectionEnd;
+      const selected = editor.value.slice(start, end) || 'code here';
+      const before = editor.value.slice(0, start);
+      const after = editor.value.slice(end);
+      editor.value = before + blockStart + selected + blockEnd + after;
+      editor.selectionStart = start + blockStart.length;
+      editor.selectionEnd = start + blockStart.length + selected.length;
+      editor.focus();
+      render();
+    });
+  });
+
+  document.querySelectorAll('.toolbar button[data-snippet]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const snippet = btn.dataset.snippet;
+      const start = editor.selectionStart;
+      const before = editor.value.slice(0, start);
+      const after = editor.value.slice(start);
+      editor.value = before + snippet + after;
+      editor.selectionStart = editor.selectionEnd = start + snippet.length;
+      editor.focus();
+      render();
+    });
+  });
+
+  document.getElementById('clearBtn').addEventListener('click', () => {
+    editor.value = '';
+    editor.focus();
+    render();
+  });
+
+  // ── Draggable divider ────────────────────────────────────────────────────
+
+  const divider = document.getElementById('divider');
+  const panesEl = document.querySelector('.panes');
+  let dragging = false;
+
+  divider.addEventListener('mousedown', e => {
+    dragging = true;
+    divider.classList.add('dragging');
+    e.preventDefault();
+  });
+
+  document.addEventListener('mousemove', e => {
+    if (!dragging) return;
+    const rect = panesEl.getBoundingClientRect();
+    const panes = panesEl.querySelectorAll('.pane');
+    const totalWidth = rect.width - 4; // subtract divider width
+    let leftRatio = (e.clientX - rect.left) / rect.width;
+    leftRatio = Math.max(0.15, Math.min(0.85, leftRatio));
+    panes[0].style.flex = 'none';
+    panes[0].style.width = (leftRatio * 100) + '%';
+    panes[1].style.flex = '1';
+    panes[1].style.width = '';
+  });
+
+  document.addEventListener('mouseup', () => {
+    if (dragging) {
+      dragging = false;
+      divider.classList.remove('dragging');
+    }
+  });
+
+  // Tab key inserts spaces in editor
+  editor.addEventListener('keydown', e => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const start = editor.selectionStart;
+      const end = editor.selectionEnd;
+      editor.value = editor.value.slice(0, start) + '  ' + editor.value.slice(end);
+      editor.selectionStart = editor.selectionEnd = start + 2;
+    }
+  });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Added `public/markdown-preview.html` — a standalone, single-file markdown preview page
- Split-pane layout: left side is a markdown editor, right side is a live preview
- Regex-based markdown parser with no external dependencies
- Supports: headers (h1–h6), bold, italic, strikethrough, inline code, fenced code blocks, unordered/ordered lists, blockquotes, tables, links, images, and horizontal rules
- Toolbar with quick-insert buttons for common formatting shortcuts
- Draggable divider to resize editor/preview panes
- Responsive design (stacks vertically on mobile)
- Tab key inserts 2 spaces in the editor

## Test plan
- [x] Tests pass locally (`pnpm test`)
- [x] Quality gate passes (`pnpm check`)

Fixes #23