### PR TITLE
feat(public): add random quote generator page (fixes #27)

### DIFF
--- a/public/quote-generator.html
+++ b/public/quote-generator.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Random Quote Generator</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0f0f13;
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      color: #e2e8f0;
+      padding: 1.5rem;
+    }
+
+    .card {
+      background: #1a1a2e;
+      border: 1px solid #2d2d44;
+      border-radius: 1.25rem;
+      padding: 3rem 2.5rem 2.5rem;
+      max-width: 640px;
+      width: 100%;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    }
+
+    .quote-mark {
+      font-size: 5rem;
+      line-height: 1;
+      color: #6c63ff;
+      font-family: Georgia, serif;
+      margin-bottom: -1rem;
+      user-select: none;
+    }
+
+    .quote-wrapper {
+      min-height: 8rem;
+      display: flex;
+      align-items: center;
+    }
+
+    .quote-text {
+      font-size: 1.25rem;
+      line-height: 1.75;
+      color: #e2e8f0;
+      font-style: italic;
+      opacity: 1;
+      transition: opacity 0.4s ease;
+    }
+
+    .quote-text.fade-out {
+      opacity: 0;
+    }
+
+    .quote-author {
+      margin-top: 1.5rem;
+      font-size: 0.95rem;
+      color: #a0aec0;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      opacity: 1;
+      transition: opacity 0.4s ease;
+    }
+
+    .quote-author.fade-out {
+      opacity: 0;
+    }
+
+    .quote-author::before {
+      content: '— ';
+      color: #6c63ff;
+    }
+
+    .divider {
+      height: 1px;
+      background: #2d2d44;
+      margin: 2rem 0;
+    }
+
+    .actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.65rem 1.4rem;
+      border-radius: 0.6rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      border: none;
+      transition: transform 0.1s ease, box-shadow 0.2s ease, background 0.2s ease;
+      white-space: nowrap;
+    }
+
+    .btn:active {
+      transform: scale(0.97);
+    }
+
+    .btn-primary {
+      background: #6c63ff;
+      color: #fff;
+    }
+
+    .btn-primary:hover {
+      background: #7c74ff;
+      box-shadow: 0 4px 20px rgba(108, 99, 255, 0.4);
+    }
+
+    .btn-secondary {
+      background: #2d2d44;
+      color: #e2e8f0;
+    }
+
+    .btn-secondary:hover {
+      background: #3a3a56;
+    }
+
+    .btn-secondary.copied {
+      background: #276749;
+      color: #9ae6b4;
+    }
+
+    .counter {
+      margin-top: 1.5rem;
+      text-align: right;
+      font-size: 0.8rem;
+      color: #4a5568;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="quote-mark">"</div>
+    <div class="quote-wrapper">
+      <p class="quote-text" id="quoteText"></p>
+    </div>
+    <p class="quote-author" id="quoteAuthor"></p>
+    <div class="divider"></div>
+    <div class="actions">
+      <button class="btn btn-primary" id="newQuoteBtn" onclick="nextQuote()">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="1 4 1 10 7 10"></polyline>
+          <path d="M3.51 15a9 9 0 1 0 .49-3.75"></path>
+        </svg>
+        New Quote
+      </button>
+      <button class="btn btn-secondary" id="copyBtn" onclick="copyQuote()">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
+        Copy
+      </button>
+    </div>
+    <p class="counter" id="counter"></p>
+  </div>
+
+  <script>
+    const quotes = [
+      { text: "The only way to do great work is to love what you do.", author: "Steve Jobs" },
+      { text: "In the middle of every difficulty lies opportunity.", author: "Albert Einstein" },
+      { text: "It does not matter how slowly you go as long as you do not stop.", author: "Confucius" },
+      { text: "Life is what happens when you're busy making other plans.", author: "John Lennon" },
+      { text: "The future belongs to those who believe in the beauty of their dreams.", author: "Eleanor Roosevelt" },
+      { text: "Strive not to be a success, but rather to be of value.", author: "Albert Einstein" },
+      { text: "In three words I can sum up everything I've learned about life: it goes on.", author: "Robert Frost" },
+      { text: "If you want to live a happy life, tie it to a goal, not to people or things.", author: "Albert Einstein" },
+      { text: "You miss 100% of the shots you don't take.", author: "Wayne Gretzky" },
+      { text: "The most common way people give up their power is by thinking they don't have any.", author: "Alice Walker" },
+      { text: "The mind is everything. What you think you become.", author: "Buddha" },
+      { text: "An unexamined life is not worth living.", author: "Socrates" },
+      { text: "Spread love everywhere you go. Let no one ever come to you without leaving happier.", author: "Mother Teresa" },
+      { text: "When you reach the end of your rope, tie a knot in it and hang on.", author: "Franklin D. Roosevelt" },
+      { text: "Always remember that you are absolutely unique. Just like everyone else.", author: "Margaret Mead" },
+      { text: "Do not go where the path may lead, go instead where there is no path and leave a trail.", author: "Ralph Waldo Emerson" },
+      { text: "You will face many defeats in life, but never let yourself be defeated.", author: "Maya Angelou" },
+      { text: "The greatest glory in living lies not in never falling, but in rising every time we fall.", author: "Nelson Mandela" },
+      { text: "In the end, it's not the years in your life that count. It's the life in your years.", author: "Abraham Lincoln" },
+      { text: "Never let the fear of striking out keep you from playing the game.", author: "Babe Ruth" },
+      { text: "Life is either a daring adventure or nothing at all.", author: "Helen Keller" },
+      { text: "Many of life's failures are people who did not realize how close they were to success when they gave up.", author: "Thomas A. Edison" },
+      { text: "It is during our darkest moments that we must focus to see the light.", author: "Aristotle" },
+    ];
+
+    let currentIndex = -1;
+
+    function getRandomIndex() {
+      if (quotes.length === 1) return 0;
+      let idx;
+      do {
+        idx = Math.floor(Math.random() * quotes.length);
+      } while (idx === currentIndex);
+      return idx;
+    }
+
+    function showQuote(index, animate) {
+      const textEl = document.getElementById('quoteText');
+      const authorEl = document.getElementById('quoteAuthor');
+      const counterEl = document.getElementById('counter');
+      const q = quotes[index];
+
+      if (animate) {
+        textEl.classList.add('fade-out');
+        authorEl.classList.add('fade-out');
+        setTimeout(() => {
+          textEl.textContent = q.text;
+          authorEl.textContent = q.author;
+          counterEl.textContent = `${index + 1} / ${quotes.length}`;
+          textEl.classList.remove('fade-out');
+          authorEl.classList.remove('fade-out');
+        }, 400);
+      } else {
+        textEl.textContent = q.text;
+        authorEl.textContent = q.author;
+        counterEl.textContent = `${index + 1} / ${quotes.length}`;
+      }
+    }
+
+    function nextQuote() {
+      currentIndex = getRandomIndex();
+      showQuote(currentIndex, true);
+      // Reset copy button if it was in "copied" state
+      const btn = document.getElementById('copyBtn');
+      btn.classList.remove('copied');
+      btn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg> Copy`;
+    }
+
+    function copyQuote() {
+      if (currentIndex < 0) return;
+      const q = quotes[currentIndex];
+      const text = `"${q.text}" — ${q.author}`;
+      navigator.clipboard.writeText(text).then(() => {
+        const btn = document.getElementById('copyBtn');
+        btn.classList.add('copied');
+        btn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg> Copied!`;
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg> Copy`;
+        }, 2000);
+      });
+    }
+
+    // Show a random quote on load
+    currentIndex = getRandomIndex();
+    showQuote(currentIndex, false);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Created `public/quote-generator.html` as a standalone, single-file page
- 23 built-in quotes from notable figures
- Fade-in animation when switching quotes (CSS opacity transition)
- Copy to clipboard button with visual feedback
- Clean dark-themed card layout, no external dependencies

## Test plan
- [x] File exists at `public/quote-generator.html`
- [x] Random quotes display correctly (avoids repeating the same quote twice in a row)
- [x] Copy to clipboard works (clipboard API with confirmation state)
- [x] No external dependencies (inline CSS/JS, no CDN links)
- [x] Quality gate passes (`pnpm check && pnpm test`)

Fixes #27