### PR TITLE
feat(public): add unit converter page (fixes #31)

### DIFF
--- a/public/unit-converter.html
+++ b/public/unit-converter.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Unit Converter</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --surface: #16213e;
+      --card: #0f3460;
+      --accent: #e94560;
+      --text: #eaeaea;
+      --text-muted: #8892a4;
+      --border: #2a2a4a;
+      --input-bg: #0d1117;
+      --radius: 8px;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+
+    h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 8px;
+      color: var(--text);
+    }
+
+    .subtitle {
+      color: var(--text-muted);
+      margin-bottom: 32px;
+      font-size: 0.9rem;
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 32px;
+      width: 100%;
+      max-width: 520px;
+    }
+
+    /* Category tabs */
+    .tabs {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 28px;
+      background: var(--input-bg);
+      border-radius: var(--radius);
+      padding: 4px;
+    }
+
+    .tab {
+      flex: 1;
+      padding: 8px 12px;
+      border: none;
+      border-radius: calc(var(--radius) - 2px);
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+    }
+
+    .tab.active {
+      background: var(--card);
+      color: var(--text);
+    }
+
+    .tab:hover:not(.active) {
+      color: var(--text);
+    }
+
+    /* Converter layout */
+    .converter {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    label {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .input-row {
+      display: flex;
+      gap: 8px;
+    }
+
+    input[type="number"] {
+      flex: 1;
+      background: var(--input-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      font-size: 1.1rem;
+      padding: 10px 14px;
+      outline: none;
+      transition: border-color 0.15s;
+      -moz-appearance: textfield;
+    }
+
+    input[type="number"]::-webkit-inner-spin-button,
+    input[type="number"]::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+    }
+
+    input[type="number"]:focus {
+      border-color: var(--accent);
+    }
+
+    select {
+      background: var(--input-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      font-size: 0.9rem;
+      padding: 10px 14px;
+      outline: none;
+      cursor: pointer;
+      min-width: 140px;
+      transition: border-color 0.15s;
+    }
+
+    select:focus {
+      border-color: var(--accent);
+    }
+
+    /* Swap button */
+    .swap-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .swap-btn {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 50%;
+      color: var(--text);
+      cursor: pointer;
+      width: 40px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.1rem;
+      transition: background 0.15s, transform 0.3s;
+    }
+
+    .swap-btn:hover {
+      background: var(--accent);
+    }
+
+    .swap-btn.rotating {
+      transform: rotate(180deg);
+    }
+  </style>
+</head>
+<body>
+  <h1>Unit Converter</h1>
+  <p class="subtitle">Real-time conversion across categories</p>
+
+  <div class="card">
+    <div class="tabs">
+      <button class="tab active" data-category="length">Length</button>
+      <button class="tab" data-category="weight">Weight</button>
+      <button class="tab" data-category="temperature">Temperature</button>
+    </div>
+
+    <div class="converter">
+      <div class="field">
+        <label>From</label>
+        <div class="input-row">
+          <input type="number" id="from-value" placeholder="0" value="1">
+          <select id="from-unit"></select>
+        </div>
+      </div>
+
+      <div class="swap-row">
+        <button class="swap-btn" id="swap-btn" title="Swap units">⇅</button>
+      </div>
+
+      <div class="field">
+        <label>To</label>
+        <div class="input-row">
+          <input type="number" id="to-value" placeholder="0" readonly>
+          <select id="to-unit"></select>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const UNITS = {
+      length: {
+        // all values relative to 1 meter
+        meter:      { label: 'Meter (m)',       factor: 1 },
+        kilometer:  { label: 'Kilometer (km)',  factor: 1000 },
+        centimeter: { label: 'Centimeter (cm)', factor: 0.01 },
+        millimeter: { label: 'Millimeter (mm)', factor: 0.001 },
+        mile:       { label: 'Mile (mi)',        factor: 1609.344 },
+        yard:       { label: 'Yard (yd)',        factor: 0.9144 },
+        foot:       { label: 'Foot (ft)',        factor: 0.3048 },
+        inch:       { label: 'Inch (in)',        factor: 0.0254 },
+      },
+      weight: {
+        // all values relative to 1 kilogram
+        kilogram: { label: 'Kilogram (kg)',  factor: 1 },
+        gram:     { label: 'Gram (g)',       factor: 0.001 },
+        milligram:{ label: 'Milligram (mg)', factor: 0.000001 },
+        pound:    { label: 'Pound (lb)',     factor: 0.45359237 },
+        ounce:    { label: 'Ounce (oz)',     factor: 0.028349523 },
+        tonne:    { label: 'Metric ton (t)', factor: 1000 },
+        stone:    { label: 'Stone (st)',     factor: 6.35029318 },
+      },
+      temperature: {
+        celsius:    { label: 'Celsius (°C)' },
+        fahrenheit: { label: 'Fahrenheit (°F)' },
+        kelvin:     { label: 'Kelvin (K)' },
+      },
+    };
+
+    // Temperature conversions (non-linear, handled separately)
+    function convertTemp(value, from, to) {
+      if (from === to) return value;
+      // Convert to Celsius first
+      let celsius;
+      if (from === 'celsius')    celsius = value;
+      if (from === 'fahrenheit') celsius = (value - 32) * 5 / 9;
+      if (from === 'kelvin')     celsius = value - 273.15;
+      // Celsius to target
+      if (to === 'celsius')    return celsius;
+      if (to === 'fahrenheit') return celsius * 9 / 5 + 32;
+      if (to === 'kelvin')     return celsius + 273.15;
+    }
+
+    function convertLinear(value, from, to, category) {
+      const units = UNITS[category];
+      const base = value * units[from].factor;   // to base unit
+      return base / units[to].factor;             // from base to target
+    }
+
+    function convert(value, from, to, category) {
+      if (from === to) return value;
+      if (category === 'temperature') return convertTemp(value, from, to);
+      return convertLinear(value, from, to, category);
+    }
+
+    function formatResult(value) {
+      if (!isFinite(value)) return '—';
+      const abs = Math.abs(value);
+      if (abs === 0) return '0';
+      if (abs >= 1e9 || (abs < 1e-4 && abs > 0)) return value.toExponential(4);
+      return parseFloat(value.toPrecision(8)).toString();
+    }
+
+    function populateSelects(category) {
+      const units = UNITS[category];
+      const keys = Object.keys(units);
+      [fromSelect, toSelect].forEach((sel, i) => {
+        sel.innerHTML = keys.map(k =>
+          `<option value="${k}">${units[k].label}</option>`
+        ).join('');
+        sel.value = keys[i === 1 ? 1 : 0];
+      });
+    }
+
+    function updateConversion() {
+      const value = parseFloat(fromInput.value);
+      if (isNaN(value)) { toInput.value = ''; return; }
+      const result = convert(value, fromSelect.value, toSelect.value, currentCategory);
+      toInput.value = formatResult(result);
+    }
+
+    let currentCategory = 'length';
+
+    const fromInput  = document.getElementById('from-value');
+    const toInput    = document.getElementById('to-value');
+    const fromSelect = document.getElementById('from-unit');
+    const toSelect   = document.getElementById('to-unit');
+    const swapBtn    = document.getElementById('swap-btn');
+
+    // Tab switching
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        currentCategory = tab.dataset.category;
+        populateSelects(currentCategory);
+        updateConversion();
+      });
+    });
+
+    // Unit selection change
+    fromSelect.addEventListener('change', updateConversion);
+    toSelect.addEventListener('change', updateConversion);
+
+    // Input change
+    fromInput.addEventListener('input', updateConversion);
+
+    // Swap
+    swapBtn.addEventListener('click', () => {
+      const tempUnit = fromSelect.value;
+      fromSelect.value = toSelect.value;
+      toSelect.value = tempUnit;
+      fromInput.value = toInput.value;
+      swapBtn.classList.add('rotating');
+      setTimeout(() => swapBtn.classList.remove('rotating'), 300);
+      updateConversion();
+    });
+
+    // Init
+    populateSelects(currentCategory);
+    updateConversion();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Created `public/unit-converter.html` — a self-contained single-file unit converter tool
- Supports three categories: **Length**, **Weight**, **Temperature** (switchable via tabs)
- Real-time conversion as you type
- Swap button (with rotation animation) to reverse from/to units
- Dark theme using CSS custom properties

## Implementation details
- Length & weight: base-unit conversion strategy (all values convert to meter/kg then to target)
- Temperature: Celsius-as-intermediate for non-linear conversions (°C, °F, K)
- Smart result formatting: exponential notation for extreme values, otherwise fixed precision

## Test plan
- [x] Tests pass locally (`pnpm test` — 29 tests pass)
- [x] Quality gate passes (`pnpm check` — format, typecheck, lint all pass)

Fixes #31