### PR TITLE
feat(public): add pomodoro timer page (fixes #32)

### DIFF
--- a/public/pomodoro.html
+++ b/public/pomodoro.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pomodoro Timer</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    :root {
+      --bg: #1a1a2e;
+      --surface: #16213e;
+      --surface2: #0f3460;
+      --work-color: #e94560;
+      --break-color: #4ecca3;
+      --text: #eaeaea;
+      --text-muted: #888;
+      --ring-track: #2a2a4a;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 300;
+      letter-spacing: 0.3em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+
+    .mode-badge {
+      display: inline-block;
+      padding: 0.25rem 1rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      background: var(--work-color);
+      color: #fff;
+      transition: background 0.4s;
+    }
+
+    .mode-badge.break {
+      background: var(--break-color);
+      color: #111;
+    }
+
+    /* Circular progress ring */
+    .ring-container {
+      position: relative;
+      width: 260px;
+      height: 260px;
+    }
+
+    .ring-container svg {
+      transform: rotate(-90deg);
+    }
+
+    .ring-track {
+      fill: none;
+      stroke: var(--ring-track);
+      stroke-width: 12;
+    }
+
+    .ring-progress {
+      fill: none;
+      stroke: var(--work-color);
+      stroke-width: 12;
+      stroke-linecap: round;
+      /* circumference = 2π × 104 ≈ 653.45 */
+      stroke-dasharray: 653.45;
+      stroke-dashoffset: 0;
+      transition: stroke-dashoffset 1s linear, stroke 0.4s;
+    }
+
+    .ring-progress.break {
+      stroke: var(--break-color);
+    }
+
+    .ring-center {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+    }
+
+    .time-display {
+      font-size: 3.5rem;
+      font-weight: 200;
+      letter-spacing: 0.05em;
+      font-variant-numeric: tabular-nums;
+      line-height: 1;
+    }
+
+    /* Controls */
+    .controls {
+      display: flex;
+      gap: 1rem;
+    }
+
+    button {
+      padding: 0.7rem 1.8rem;
+      border: none;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      transition: opacity 0.2s, transform 0.1s;
+    }
+
+    button:active {
+      transform: scale(0.96);
+    }
+
+    #btn-start {
+      background: var(--work-color);
+      color: #fff;
+      min-width: 100px;
+    }
+
+    #btn-start.break-mode {
+      background: var(--break-color);
+      color: #111;
+    }
+
+    #btn-reset {
+      background: var(--surface2);
+      color: var(--text);
+    }
+
+    button:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    /* Session dots */
+    .sessions-section {
+      text-align: center;
+    }
+
+    .sessions-label {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+
+    .session-dots {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+      flex-wrap: wrap;
+      max-width: 200px;
+    }
+
+    .dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: var(--ring-track);
+      transition: background 0.3s;
+    }
+
+    .dot.filled {
+      background: var(--work-color);
+    }
+
+    /* Notification flash */
+    body.flash {
+      animation: flash 0.4s ease;
+    }
+
+    @keyframes flash {
+      0%   { background: var(--bg); }
+      50%  { background: #2a1a2e; }
+      100% { background: var(--bg); }
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Pomodoro</h1>
+  <span id="mode-badge" class="mode-badge">Work</span>
+
+  <div class="ring-container">
+    <svg width="260" height="260" viewBox="0 0 260 260">
+      <circle class="ring-track" cx="130" cy="130" r="104"/>
+      <circle id="ring-progress" class="ring-progress" cx="130" cy="130" r="104"/>
+    </svg>
+    <div class="ring-center">
+      <div id="time-display" class="time-display">25:00</div>
+    </div>
+  </div>
+
+  <div class="controls">
+    <button id="btn-start">Start</button>
+    <button id="btn-reset">Reset</button>
+  </div>
+
+  <div class="sessions-section">
+    <div class="sessions-label">Sessions completed</div>
+    <div id="session-dots" class="session-dots"></div>
+  </div>
+
+<script>
+  const WORK_SECONDS  = 25 * 60;
+  const BREAK_SECONDS = 5 * 60;
+  const CIRCUMFERENCE = 2 * Math.PI * 104; // ≈ 653.45
+
+  let totalSeconds   = WORK_SECONDS;
+  let remaining      = WORK_SECONDS;
+  let isRunning      = false;
+  let isBreak        = false;
+  let sessions       = 0;
+  let intervalId     = null;
+
+  const timeDisplay  = document.getElementById('time-display');
+  const ringProgress = document.getElementById('ring-progress');
+  const modeBadge    = document.getElementById('mode-badge');
+  const btnStart     = document.getElementById('btn-start');
+  const btnReset     = document.getElementById('btn-reset');
+  const sessionDots  = document.getElementById('session-dots');
+
+  function formatTime(secs) {
+    const m = String(Math.floor(secs / 60)).padStart(2, '0');
+    const s = String(secs % 60).padStart(2, '0');
+    return `${m}:${s}`;
+  }
+
+  function updateRing() {
+    const fraction = remaining / totalSeconds;
+    const offset = CIRCUMFERENCE * (1 - fraction);
+    ringProgress.style.strokeDashoffset = offset;
+  }
+
+  function updateDisplay() {
+    timeDisplay.textContent = formatTime(remaining);
+    updateRing();
+  }
+
+  function setMode(breakMode) {
+    isBreak = breakMode;
+    totalSeconds = isBreak ? BREAK_SECONDS : WORK_SECONDS;
+    remaining    = totalSeconds;
+
+    modeBadge.textContent = isBreak ? 'Break' : 'Work';
+    modeBadge.classList.toggle('break', isBreak);
+    ringProgress.classList.toggle('break', isBreak);
+    btnStart.classList.toggle('break-mode', isBreak);
+
+    updateDisplay();
+  }
+
+  function addSessionDot(filled) {
+    const dot = document.createElement('div');
+    dot.className = 'dot' + (filled ? ' filled' : '');
+    sessionDots.appendChild(dot);
+  }
+
+  function playBeep() {
+    try {
+      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      const beepAt = (startTime) => {
+        const osc  = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.type = 'sine';
+        osc.frequency.value = 880;
+        gain.gain.setValueAtTime(0.3, startTime);
+        gain.gain.exponentialRampToValueAtTime(0.001, startTime + 0.25);
+        osc.start(startTime);
+        osc.stop(startTime + 0.25);
+      };
+      const now = ctx.currentTime;
+      beepAt(now);
+      beepAt(now + 0.35);
+      beepAt(now + 0.70);
+    } catch (_) {
+      // Silently fail if AudioContext unavailable
+    }
+  }
+
+  function flashScreen() {
+    document.body.classList.remove('flash');
+    // Force reflow to restart animation
+    void document.body.offsetWidth;
+    document.body.classList.add('flash');
+  }
+
+  function tick() {
+    if (remaining <= 0) {
+      clearInterval(intervalId);
+      intervalId = null;
+      isRunning = false;
+      playBeep();
+      flashScreen();
+
+      if (!isBreak) {
+        // Work session completed
+        sessions++;
+        addSessionDot(true);
+        setMode(true); // switch to break
+        // Auto-start break
+        startTimer();
+      } else {
+        // Break completed — return to work, don't auto-start
+        setMode(false);
+        btnStart.textContent = 'Start';
+      }
+      return;
+    }
+    remaining--;
+    updateDisplay();
+  }
+
+  function startTimer() {
+    if (isRunning) return;
+    isRunning = true;
+    btnStart.textContent = 'Pause';
+    intervalId = setInterval(tick, 1000);
+  }
+
+  function pauseTimer() {
+    if (!isRunning) return;
+    isRunning = false;
+    clearInterval(intervalId);
+    intervalId = null;
+    btnStart.textContent = 'Resume';
+  }
+
+  function resetTimer() {
+    pauseTimer();
+    setMode(false);
+    btnStart.textContent = 'Start';
+  }
+
+  btnStart.addEventListener('click', () => {
+    if (isRunning) {
+      pauseTimer();
+    } else {
+      startTimer();
+    }
+  });
+
+  btnReset.addEventListener('click', resetTimer);
+
+  // Initial render
+  updateDisplay();
+  // Pre-fill 8 empty dots (typical daily goal)
+  for (let i = 0; i < 8; i++) addSessionDot(false);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Created `public/pomodoro.html` — a single-file dark-theme pomodoro timer
- 25min work / 5min break cycle with automatic break start after work session
- SVG circular progress ring (r=104, circumference ≈ 653.45) animating via stroke-dashoffset
- Start / Pause / Resume / Reset controls
- Web Audio API synthesized 880Hz triple-beep on timer completion
- Session counter with 8 dot indicators (filled dots = completed sessions)
- Fully self-contained — no external dependencies

## Test plan
- [x] Tests pass locally (`pnpm test` — 29/29)
- [x] Quality gate passes (`pnpm check`)
- [x] HTML file opens in browser and all controls work

Fixes #32