### PR TITLE
feat(public): add password generator page (fixes #30)

### DIFF
--- a/public/password-generator.html
+++ b/public/password-generator.html
@@ -1,0 +1,468 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Password Generator</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f1117;
+      --surface: #1a1d27;
+      --surface2: #22253a;
+      --border: #2e3250;
+      --accent: #6c63ff;
+      --accent-hover: #7c74ff;
+      --text: #e2e4f0;
+      --text-muted: #7a7f9a;
+      --weak: #ef4444;
+      --medium: #f59e0b;
+      --strong: #22c55e;
+      --radius: 10px;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 2rem;
+      width: 100%;
+      max-width: 460px;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+    }
+
+    h1 {
+      font-size: 1.4rem;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      margin-bottom: 1.5rem;
+      text-align: center;
+      color: var(--text);
+    }
+
+    /* Password output */
+    .output-area {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 0.9rem 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    #password-display {
+      flex: 1;
+      font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+      font-size: 1rem;
+      color: var(--text);
+      word-break: break-all;
+      min-height: 1.5em;
+      user-select: all;
+    }
+
+    #copy-btn {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text-muted);
+      cursor: pointer;
+      padding: 0.3rem 0.5rem;
+      transition: all 0.15s;
+      flex-shrink: 0;
+    }
+
+    #copy-btn:hover { color: var(--accent); border-color: var(--accent); }
+    #copy-btn.copied { color: var(--strong); border-color: var(--strong); }
+
+    /* Strength indicator */
+    .strength-bar-wrapper {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 0.4rem;
+    }
+
+    .strength-segment {
+      height: 4px;
+      flex: 1;
+      border-radius: 2px;
+      background: var(--border);
+      transition: background 0.25s;
+    }
+
+    #strength-label {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-bottom: 1.25rem;
+      min-height: 1.1em;
+    }
+
+    /* Controls */
+    .section-label {
+      font-size: 0.8rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--text-muted);
+      margin-bottom: 0.6rem;
+    }
+
+    /* Slider */
+    .slider-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1.25rem;
+    }
+
+    #length-slider {
+      flex: 1;
+      -webkit-appearance: none;
+      height: 4px;
+      border-radius: 2px;
+      background: var(--border);
+      outline: none;
+      cursor: pointer;
+    }
+
+    #length-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--accent);
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    #length-slider::-webkit-slider-thumb:hover { background: var(--accent-hover); }
+
+    #length-slider::-moz-range-thumb {
+      width: 16px;
+      height: 16px;
+      border: none;
+      border-radius: 50%;
+      background: var(--accent);
+      cursor: pointer;
+    }
+
+    #length-value {
+      font-size: 0.9rem;
+      font-weight: 600;
+      min-width: 2.2em;
+      text-align: right;
+      color: var(--accent);
+    }
+
+    /* Checkboxes */
+    .checkbox-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .checkbox-item {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      cursor: pointer;
+      user-select: none;
+      padding: 0.55rem 0.75rem;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--surface2);
+      transition: border-color 0.15s;
+    }
+
+    .checkbox-item:has(input:checked) {
+      border-color: var(--accent);
+    }
+
+    .checkbox-item input[type="checkbox"] {
+      -webkit-appearance: none;
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--border);
+      border-radius: 4px;
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: all 0.15s;
+      position: relative;
+    }
+
+    .checkbox-item input[type="checkbox"]:checked {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+
+    .checkbox-item input[type="checkbox"]:checked::after {
+      content: '';
+      position: absolute;
+      left: 3px;
+      top: 0px;
+      width: 5px;
+      height: 9px;
+      border: 2px solid #fff;
+      border-top: none;
+      border-left: none;
+      transform: rotate(45deg);
+    }
+
+    .checkbox-label {
+      font-size: 0.85rem;
+      color: var(--text);
+    }
+
+    .char-preview {
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      font-family: monospace;
+    }
+
+    /* Generate button */
+    #generate-btn {
+      width: 100%;
+      padding: 0.8rem;
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      border-radius: var(--radius);
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s, transform 0.1s;
+      letter-spacing: 0.02em;
+    }
+
+    #generate-btn:hover { background: var(--accent-hover); }
+    #generate-btn:active { transform: scale(0.98); }
+    #generate-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .error-msg {
+      font-size: 0.8rem;
+      color: var(--weak);
+      text-align: center;
+      margin-top: 0.75rem;
+      min-height: 1.1em;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Password Generator</h1>
+
+    <div class="output-area">
+      <span id="password-display" aria-label="Generated password" aria-live="polite"></span>
+      <button id="copy-btn" title="Copy to clipboard" aria-label="Copy password">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
+      </button>
+    </div>
+
+    <div class="strength-bar-wrapper" role="progressbar" aria-label="Password strength" aria-valuemin="0" aria-valuemax="3" aria-valuenow="0">
+      <div class="strength-segment" id="seg0"></div>
+      <div class="strength-segment" id="seg1"></div>
+      <div class="strength-segment" id="seg2"></div>
+    </div>
+    <div id="strength-label"></div>
+
+    <div class="section-label">Length</div>
+    <div class="slider-row">
+      <input type="range" id="length-slider" min="8" max="64" value="16" aria-label="Password length" />
+      <span id="length-value">16</span>
+    </div>
+
+    <div class="section-label">Character Types</div>
+    <div class="checkbox-grid">
+      <label class="checkbox-item">
+        <input type="checkbox" id="opt-uppercase" checked />
+        <span>
+          <div class="checkbox-label">Uppercase</div>
+          <div class="char-preview">A–Z</div>
+        </span>
+      </label>
+      <label class="checkbox-item">
+        <input type="checkbox" id="opt-lowercase" checked />
+        <span>
+          <div class="checkbox-label">Lowercase</div>
+          <div class="char-preview">a–z</div>
+        </span>
+      </label>
+      <label class="checkbox-item">
+        <input type="checkbox" id="opt-numbers" checked />
+        <span>
+          <div class="checkbox-label">Numbers</div>
+          <div class="char-preview">0–9</div>
+        </span>
+      </label>
+      <label class="checkbox-item">
+        <input type="checkbox" id="opt-symbols" />
+        <span>
+          <div class="checkbox-label">Symbols</div>
+          <div class="char-preview">!@#$%^&*</div>
+        </span>
+      </label>
+    </div>
+
+    <button id="generate-btn">Generate Password</button>
+    <div class="error-msg" id="error-msg" role="alert"></div>
+  </div>
+
+  <script>
+    const CHARS = {
+      uppercase: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      lowercase: 'abcdefghijklmnopqrstuvwxyz',
+      numbers:   '0123456789',
+      symbols:   '!@#$%^&*()_+-=[]{}|;:,.<>?',
+    };
+
+    const display    = document.getElementById('password-display');
+    const copyBtn    = document.getElementById('copy-btn');
+    const generateBtn = document.getElementById('generate-btn');
+    const slider     = document.getElementById('length-slider');
+    const lengthVal  = document.getElementById('length-value');
+    const errorMsg   = document.getElementById('error-msg');
+    const strengthLabel = document.getElementById('strength-label');
+    const segments   = [document.getElementById('seg0'), document.getElementById('seg1'), document.getElementById('seg2')];
+
+    const opts = {
+      uppercase: document.getElementById('opt-uppercase'),
+      lowercase: document.getElementById('opt-lowercase'),
+      numbers:   document.getElementById('opt-numbers'),
+      symbols:   document.getElementById('opt-symbols'),
+    };
+
+    // Sync slider display
+    slider.addEventListener('input', () => {
+      lengthVal.textContent = slider.value;
+      if (display.textContent) generatePassword();
+    });
+
+    // Re-generate when options change
+    Object.values(opts).forEach(cb => {
+      cb.addEventListener('change', () => {
+        if (display.textContent) generatePassword();
+        else validateOptions();
+      });
+    });
+
+    generateBtn.addEventListener('click', generatePassword);
+
+    function validateOptions() {
+      const anyChecked = Object.values(opts).some(cb => cb.checked);
+      errorMsg.textContent = anyChecked ? '' : 'Select at least one character type.';
+      generateBtn.disabled = !anyChecked;
+      return anyChecked;
+    }
+
+    function buildCharset() {
+      let charset = '';
+      for (const [key, cb] of Object.entries(opts)) {
+        if (cb.checked) charset += CHARS[key];
+      }
+      return charset;
+    }
+
+    function generatePassword() {
+      if (!validateOptions()) return;
+
+      const length = parseInt(slider.value, 10);
+      const charset = buildCharset();
+
+      // Use crypto.getRandomValues for cryptographically secure generation
+      const array = new Uint32Array(length);
+      crypto.getRandomValues(array);
+      const password = Array.from(array, n => charset[n % charset.length]).join('');
+
+      display.textContent = password;
+      errorMsg.textContent = '';
+      updateStrength(password);
+    }
+
+    function updateStrength(password) {
+      const score = calcStrength(password);
+      const colors = ['var(--weak)', 'var(--medium)', 'var(--strong)'];
+      const labels = [
+        { text: 'Weak', color: 'var(--weak)' },
+        { text: 'Medium', color: 'var(--medium)' },
+        { text: 'Strong', color: 'var(--strong)' },
+      ];
+
+      segments.forEach((seg, i) => {
+        seg.style.background = i <= score ? colors[score] : 'var(--border)';
+      });
+
+      const { text, color } = labels[score];
+      strengthLabel.textContent = `Strength: ${text}`;
+      strengthLabel.style.color = color;
+
+      const bar = document.querySelector('.strength-bar-wrapper');
+      bar.setAttribute('aria-valuenow', score + 1);
+    }
+
+    function calcStrength(password) {
+      let score = 0;
+      const len = password.length;
+
+      // Length contribution
+      if (len >= 16) score++;
+      if (len >= 24) score++;
+
+      // Character variety
+      const hasUpper   = /[A-Z]/.test(password);
+      const hasLower   = /[a-z]/.test(password);
+      const hasDigit   = /[0-9]/.test(password);
+      const hasSymbol  = /[^A-Za-z0-9]/.test(password);
+      const variety = [hasUpper, hasLower, hasDigit, hasSymbol].filter(Boolean).length;
+
+      if (variety >= 3) score++;
+      if (variety === 4) score++;
+
+      // Clamp to 0-2 (maps to weak/medium/strong)
+      return Math.min(2, Math.max(0, score - (len < 12 ? 1 : 0)));
+    }
+
+    copyBtn.addEventListener('click', async () => {
+      const pwd = display.textContent;
+      if (!pwd) return;
+      try {
+        await navigator.clipboard.writeText(pwd);
+        copyBtn.classList.add('copied');
+        copyBtn.title = 'Copied!';
+        setTimeout(() => {
+          copyBtn.classList.remove('copied');
+          copyBtn.title = 'Copy to clipboard';
+        }, 1500);
+      } catch {
+        // Fallback for non-secure contexts
+        const range = document.createRange();
+        range.selectNodeContents(display);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+        document.execCommand('copy');
+        sel.removeAllRanges();
+      }
+    });
+
+    // Generate on load
+    generatePassword();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Created `public/password-generator.html` — a fully self-contained, single-file password generator tool
- Password length slider (8–64 characters)
- Character type checkboxes: Uppercase (A–Z), Lowercase (a–z), Numbers (0–9), Symbols (!@#\$%^&*)
- Generate button with cryptographically secure generation via `crypto.getRandomValues`
- Copy to clipboard with clipboard API + execCommand fallback
- Password strength indicator (Weak / Medium / Strong) based on length and character variety
- Dark theme with accessible, responsive layout

## Test plan
- [x] Tests pass locally (`pnpm test` — 29 tests pass)
- [x] Quality gate passes (`pnpm check` — format, typecheck, lint all pass)
- [x] HTML file opens in browser and all features work correctly

Fixes #30