### PR TITLE
fix(app): return 204 for favicon.ico to suppress 404 log noise (fixes #40)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -8,6 +8,13 @@ beforeEach(() => {
 });
 
 describe("API", () => {
+  describe("GET /favicon.ico", () => {
+    it("returns 204 silently", async () => {
+      const res = await request(app).get("/favicon.ico");
+      expect(res.status).toBe(204);
+    });
+  });
+
   describe("POST /todos", () => {
     it("creates a todo", async () => {
       const res = await request(app).post("/todos").send({ title: "Buy milk" });

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,11 @@ import { getStats } from "./stats.js";
 export const app: Express = express();
 app.use(express.json());
 
+// Suppress favicon 404 noise
+app.get("/favicon.ico", (_req, res) => {
+  res.status(204).end();
+});
+
 // Health check
 app.get("/health", healthCheck);
 


### PR DESCRIPTION
## Summary
- Added `GET /favicon.ico` route to `app.ts` that returns 204 No Content
- Prevents browsers from triggering 404 errors in server logs on every page load
- Added test verifying the route returns 204 silently

## Test plan
- [x] Tests pass locally (`pnpm test` — 30/30 pass)
- [x] Quality gate passes (`pnpm check` — format, typecheck, lint all clean)

Fixes #40