### PR TITLE
feat(public): add BMI calculator page (fixes #39)

### DIFF
--- a/public/bmi-calculator.html
+++ b/public/bmi-calculator.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BMI Calculator</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --surface: #16213e;
+      --card: #0f3460;
+      --accent: #e94560;
+      --text: #eaeaea;
+      --text-muted: #8892a4;
+      --border: #2a2a4a;
+      --input-bg: #0d1117;
+      --radius: 8px;
+      --underweight: #4fc3f7;
+      --normal: #4ecca3;
+      --overweight: #ffb74d;
+      --obese: #e94560;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+
+    h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 8px;
+      color: var(--text);
+    }
+
+    .subtitle {
+      color: var(--text-muted);
+      margin-bottom: 32px;
+      font-size: 0.9rem;
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 32px;
+      width: 100%;
+      max-width: 420px;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-bottom: 20px;
+    }
+
+    label {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .input-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    input[type="number"] {
+      flex: 1;
+      background: var(--input-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      font-size: 1.1rem;
+      padding: 10px 14px;
+      outline: none;
+      transition: border-color 0.15s;
+      -moz-appearance: textfield;
+    }
+
+    input[type="number"]::-webkit-inner-spin-button,
+    input[type="number"]::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+    }
+
+    input[type="number"]:focus {
+      border-color: var(--accent);
+    }
+
+    input[type="number"].invalid {
+      border-color: var(--accent);
+    }
+
+    .unit {
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      min-width: 32px;
+    }
+
+    .error {
+      font-size: 0.75rem;
+      color: var(--accent);
+      min-height: 1em;
+    }
+
+    .calc-btn {
+      width: 100%;
+      padding: 12px;
+      background: var(--accent);
+      border: none;
+      border-radius: var(--radius);
+      color: #fff;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s;
+      margin-top: 8px;
+    }
+
+    .calc-btn:hover {
+      opacity: 0.88;
+    }
+
+    .calc-btn:active {
+      opacity: 0.75;
+    }
+
+    .result {
+      margin-top: 28px;
+      padding: 20px;
+      background: var(--input-bg);
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      display: none;
+      text-align: center;
+    }
+
+    .result.visible {
+      display: block;
+    }
+
+    .bmi-value {
+      font-size: 3rem;
+      font-weight: 700;
+      line-height: 1;
+      margin-bottom: 8px;
+    }
+
+    .bmi-category {
+      font-size: 1.1rem;
+      font-weight: 600;
+      margin-bottom: 16px;
+    }
+
+    .scale {
+      display: flex;
+      border-radius: 4px;
+      overflow: hidden;
+      height: 8px;
+      margin-bottom: 12px;
+    }
+
+    .scale-segment {
+      flex: 1;
+      opacity: 0.45;
+      transition: opacity 0.3s;
+    }
+
+    .scale-segment.active {
+      opacity: 1;
+    }
+
+    .scale-underweight { background: var(--underweight); }
+    .scale-normal      { background: var(--normal); flex: 1.5; }
+    .scale-overweight  { background: var(--overweight); }
+    .scale-obese       { background: var(--obese); }
+
+    .scale-labels {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.7rem;
+      color: var(--text-muted);
+    }
+  </style>
+</head>
+<body>
+  <h1>BMI Calculator</h1>
+  <p class="subtitle">Body Mass Index — a simple health screening tool</p>
+
+  <div class="card">
+    <div class="field">
+      <label for="height">Height</label>
+      <div class="input-row">
+        <input type="number" id="height" placeholder="170" min="1" max="300">
+        <span class="unit">cm</span>
+      </div>
+      <span class="error" id="height-error"></span>
+    </div>
+
+    <div class="field">
+      <label for="weight">Weight</label>
+      <div class="input-row">
+        <input type="number" id="weight" placeholder="70" min="1" max="700">
+        <span class="unit">kg</span>
+      </div>
+      <span class="error" id="weight-error"></span>
+    </div>
+
+    <button class="calc-btn" id="calc-btn">Calculate BMI</button>
+
+    <div class="result" id="result">
+      <div class="bmi-value" id="bmi-value">—</div>
+      <div class="bmi-category" id="bmi-category">—</div>
+      <div class="scale">
+        <div class="scale-segment scale-underweight" id="seg-underweight"></div>
+        <div class="scale-segment scale-normal"      id="seg-normal"></div>
+        <div class="scale-segment scale-overweight"  id="seg-overweight"></div>
+        <div class="scale-segment scale-obese"       id="seg-obese"></div>
+      </div>
+      <div class="scale-labels">
+        <span>Underweight</span>
+        <span>Normal</span>
+        <span>Overweight</span>
+        <span>Obese</span>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const heightInput  = document.getElementById('height');
+    const weightInput  = document.getElementById('weight');
+    const heightError  = document.getElementById('height-error');
+    const weightError  = document.getElementById('weight-error');
+    const calcBtn      = document.getElementById('calc-btn');
+    const resultBox    = document.getElementById('result');
+    const bmiValueEl   = document.getElementById('bmi-value');
+    const bmiCategoryEl= document.getElementById('bmi-category');
+
+    const CATEGORIES = [
+      { id: 'seg-underweight', label: 'Underweight', color: 'var(--underweight)', max: 18.5 },
+      { id: 'seg-normal',      label: 'Normal',      color: 'var(--normal)',      max: 25 },
+      { id: 'seg-overweight',  label: 'Overweight',  color: 'var(--overweight)',  max: 30 },
+      { id: 'seg-obese',       label: 'Obese',       color: 'var(--obese)',       max: Infinity },
+    ];
+
+    function getCategory(bmi) {
+      return CATEGORIES.find(c => bmi < c.max) ?? CATEGORIES[CATEGORIES.length - 1];
+    }
+
+    function validate() {
+      const h = parseFloat(heightInput.value);
+      const w = parseFloat(weightInput.value);
+      let valid = true;
+
+      if (!heightInput.value || isNaN(h) || h <= 0) {
+        heightError.textContent = 'Enter a positive height in cm';
+        heightInput.classList.add('invalid');
+        valid = false;
+      } else {
+        heightError.textContent = '';
+        heightInput.classList.remove('invalid');
+      }
+
+      if (!weightInput.value || isNaN(w) || w <= 0) {
+        weightError.textContent = 'Enter a positive weight in kg';
+        weightInput.classList.add('invalid');
+        valid = false;
+      } else {
+        weightError.textContent = '';
+        weightInput.classList.remove('invalid');
+      }
+
+      return valid ? { h, w } : null;
+    }
+
+    function calculate() {
+      const values = validate();
+      if (!values) return;
+
+      const { h, w } = values;
+      const bmi = w / Math.pow(h / 100, 2);
+      const cat = getCategory(bmi);
+
+      bmiValueEl.textContent = bmi.toFixed(1);
+      bmiValueEl.style.color = cat.color;
+      bmiCategoryEl.textContent = cat.label;
+      bmiCategoryEl.style.color = cat.color;
+
+      // Highlight active scale segment
+      CATEGORIES.forEach(c => {
+        document.getElementById(c.id).classList.toggle('active', c.id === cat.id);
+      });
+
+      resultBox.classList.add('visible');
+    }
+
+    calcBtn.addEventListener('click', calculate);
+
+    // Allow Enter key to trigger calculation
+    [heightInput, weightInput].forEach(input => {
+      input.addEventListener('keydown', e => {
+        if (e.key === 'Enter') calculate();
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `public/bmi-calculator.html` — a standalone BMI calculator page
- Height (cm) + weight (kg) inputs with positive-number validation
- Computes BMI = weight / (height/100)² and shows rounded result
- Color-coded category display: Underweight / Normal / Overweight / Obese
- Visual scale bar highlights the active category
- Enter key triggers calculation alongside the button
- Dark theme consistent with existing pages in `public/`

## Test plan
- [x] Tests pass locally (`pnpm test` — 29/29)
- [x] Quality gate passes (`pnpm check`)
- [x] BMI formula verified: 70 kg / (1.75 m)² = 22.9 (Normal)
- [x] Input validation rejects zero, negative, and empty values

Fixes #39