### PR TITLE
feat(public): add color palette generator page (fixes #41)

### DIFF
--- a/public/color-palette.html
+++ b/public/color-palette.html
@@ -1,0 +1,478 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Color Palette Generator</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f1117;
+      --surface: #1a1d27;
+      --surface2: #22253a;
+      --border: #2e3250;
+      --accent: #6c63ff;
+      --accent-hover: #7c74ff;
+      --text: #e2e4f0;
+      --text-muted: #7a7f9a;
+      --success: #22c55e;
+      --radius: 12px;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 2rem 1rem;
+    }
+
+    h1 {
+      font-size: 1.6rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 0.4rem;
+      color: var(--text);
+    }
+
+    .subtitle {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 1.75rem;
+    }
+
+    /* ── Controls ── */
+    .controls {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    .harmony-select {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      color: var(--text);
+      border-radius: 8px;
+      padding: 0.55rem 0.9rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+
+    .harmony-select:hover,
+    .harmony-select:focus { border-color: var(--accent); }
+
+    .btn-generate {
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      padding: 0.6rem 1.4rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s, transform 0.1s;
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+    }
+
+    .btn-generate:hover { background: var(--accent-hover); }
+    .btn-generate:active { transform: scale(0.97); }
+
+    /* ── Palette grid ── */
+    .palette {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 0.75rem;
+      width: 100%;
+      max-width: 840px;
+    }
+
+    @media (max-width: 680px) {
+      .palette { grid-template-columns: repeat(2, 1fr); }
+      .palette .swatch-card:last-child { grid-column: span 2; }
+    }
+
+    @media (max-width: 400px) {
+      .palette { grid-template-columns: 1fr; }
+      .palette .swatch-card:last-child { grid-column: span 1; }
+    }
+
+    /* ── Swatch card ── */
+    .swatch-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      transition: transform 0.15s, box-shadow 0.15s;
+    }
+
+    .swatch-card:hover { transform: translateY(-2px); box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
+
+    .swatch-card.locked { border-color: var(--accent); }
+
+    /* Color block — clickable to copy hex */
+    .color-block {
+      height: 140px;
+      cursor: pointer;
+      position: relative;
+      transition: filter 0.15s;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .color-block:hover { filter: brightness(1.08); }
+
+    .copy-hint {
+      opacity: 0;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: rgba(255,255,255,0.9);
+      text-shadow: 0 1px 4px rgba(0,0,0,0.6);
+      transition: opacity 0.15s;
+      pointer-events: none;
+    }
+
+    .color-block:hover .copy-hint { opacity: 1; }
+
+    /* Card info */
+    .card-info {
+      padding: 0.7rem 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.3rem;
+    }
+
+    .hex-value {
+      font-family: 'Cascadia Code', 'Fira Code', monospace;
+      font-size: 0.9rem;
+      font-weight: 700;
+      color: var(--text);
+      letter-spacing: 0.03em;
+    }
+
+    .rgb-value {
+      font-size: 0.72rem;
+      color: var(--text-muted);
+      font-family: monospace;
+    }
+
+    /* Card footer: lock button */
+    .card-footer {
+      padding: 0.4rem 0.75rem 0.7rem;
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .btn-lock {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+      border-radius: 6px;
+      padding: 0.25rem 0.55rem;
+      font-size: 0.72rem;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 0.3rem;
+      transition: all 0.15s;
+      white-space: nowrap;
+    }
+
+    .btn-lock:hover { border-color: var(--accent); color: var(--text); }
+
+    .swatch-card.locked .btn-lock {
+      background: rgba(108, 99, 255, 0.15);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    /* ── Toast ── */
+    #toast {
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%) translateY(80px);
+      background: var(--success);
+      color: #fff;
+      padding: 0.55rem 1.2rem;
+      border-radius: 8px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      transition: transform 0.25s ease;
+      pointer-events: none;
+      z-index: 100;
+    }
+
+    #toast.show { transform: translateX(-50%) translateY(0); }
+
+    /* ── Copied flash on block ── */
+    .color-block.flash::after {
+      content: 'Copied!';
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #fff;
+      text-shadow: 0 1px 4px rgba(0,0,0,0.7);
+      background: rgba(34, 197, 94, 0.35);
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Color Palette Generator</h1>
+  <p class="subtitle">Generate harmonious color palettes. Click a swatch to copy its hex code.</p>
+
+  <div class="controls">
+    <select class="harmony-select" id="harmonySelect" title="Color harmony mode">
+      <option value="analogous">Analogous</option>
+      <option value="complementary">Complementary</option>
+      <option value="triadic">Triadic</option>
+      <option value="split-complementary">Split-Complementary</option>
+      <option value="random">Random</option>
+    </select>
+    <button class="btn-generate" id="generateBtn">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M1 8a7 7 0 1 0 7-7"/>
+        <polyline points="1 1 1 8 8 8"/>
+      </svg>
+      Generate
+    </button>
+  </div>
+
+  <div class="palette" id="palette">
+    <!-- 5 swatch cards rendered by JS -->
+  </div>
+
+  <div id="toast"></div>
+
+  <script>
+    /* ────────────────────────────────────────
+       Color math
+    ──────────────────────────────────────── */
+
+    /** Convert HSL → {r,g,b} (0-255) */
+    function hslToRgb(h, s, l) {
+      h = ((h % 360) + 360) % 360;
+      s /= 100; l /= 100;
+      const c = (1 - Math.abs(2 * l - 1)) * s;
+      const x = c * (1 - Math.abs((h / 60) % 2 - 1));
+      const m = l - c / 2;
+      let r = 0, g = 0, b = 0;
+      if      (h < 60)  { r = c; g = x; }
+      else if (h < 120) { r = x; g = c; }
+      else if (h < 180) { g = c; b = x; }
+      else if (h < 240) { g = x; b = c; }
+      else if (h < 300) { r = x; b = c; }
+      else              { r = c; b = x; }
+      return {
+        r: Math.round((r + m) * 255),
+        g: Math.round((g + m) * 255),
+        b: Math.round((b + m) * 255),
+      };
+    }
+
+    /** {r,g,b} → '#rrggbb' */
+    function toHex(r, g, b) {
+      return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+    }
+
+    /**
+     * Generate 5 hue offsets based on harmony mode.
+     * Returns array of 5 hue values (0-360).
+     */
+    function harmonyHues(baseHue, mode) {
+      const h = ((baseHue % 360) + 360) % 360;
+      switch (mode) {
+        case 'analogous':
+          return [h - 40, h - 20, h, h + 20, h + 40];
+        case 'complementary': {
+          const comp = (h + 180) % 360;
+          return [h - 20, h, h + 20, comp - 15, comp + 15];
+        }
+        case 'triadic': {
+          const t1 = (h + 120) % 360;
+          const t2 = (h + 240) % 360;
+          return [h - 15, h + 15, t1 - 10, t1 + 10, t2];
+        }
+        case 'split-complementary': {
+          const s1 = (h + 150) % 360;
+          const s2 = (h + 210) % 360;
+          return [h - 10, h, h + 10, s1, s2];
+        }
+        case 'random':
+        default:
+          return Array.from({ length: 5 }, () => Math.random() * 360);
+      }
+    }
+
+    /**
+     * Generate a palette: array of 5 { hex, r, g, b, h, s, l, locked }.
+     * Locked colors retain their current values.
+     */
+    function generatePalette(existingColors, mode) {
+      const baseHue = Math.random() * 360;
+      const hues = harmonyHues(baseHue, mode);
+      return hues.map((hue, i) => {
+        if (existingColors[i] && existingColors[i].locked) {
+          return existingColors[i]; // preserve locked
+        }
+        const s = 55 + Math.random() * 30; // 55–85%
+        const l = 40 + Math.random() * 25; // 40–65%
+        const { r, g, b } = hslToRgb(hue, s, l);
+        return { hex: toHex(r, g, b), r, g, b, h: hue, s, l, locked: false };
+      });
+    }
+
+    /* ────────────────────────────────────────
+       State
+    ──────────────────────────────────────── */
+    let palette = [];
+
+    /* ────────────────────────────────────────
+       Render
+    ──────────────────────────────────────── */
+    function render() {
+      const container = document.getElementById('palette');
+      container.innerHTML = '';
+      palette.forEach((color, i) => {
+        const card = document.createElement('div');
+        card.className = 'swatch-card' + (color.locked ? ' locked' : '');
+        card.innerHTML = `
+          <div class="color-block" style="background:${color.hex}" data-index="${i}" role="button" tabindex="0" aria-label="Copy ${color.hex}">
+            <span class="copy-hint">Click to copy</span>
+          </div>
+          <div class="card-info">
+            <div class="hex-value">${color.hex}</div>
+            <div class="rgb-value">rgb(${color.r}, ${color.g}, ${color.b})</div>
+          </div>
+          <div class="card-footer">
+            <button class="btn-lock" data-index="${i}" aria-pressed="${color.locked}" aria-label="${color.locked ? 'Unlock' : 'Lock'} color ${color.hex}">
+              ${color.locked ? lockIcon() : unlockIcon()} ${color.locked ? 'Locked' : 'Lock'}
+            </button>
+          </div>
+        `;
+        container.appendChild(card);
+      });
+    }
+
+    function lockIcon() {
+      return `<svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="7" width="10" height="8" rx="2"/><path d="M5 7V5a3 3 0 0 1 6 0v2"/></svg>`;
+    }
+
+    function unlockIcon() {
+      return `<svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="7" width="10" height="8" rx="2"/><path d="M5 7V5a3 3 0 0 1 5.83-.83"/></svg>`;
+    }
+
+    /* ────────────────────────────────────────
+       Copy to clipboard
+    ──────────────────────────────────────── */
+    let toastTimer;
+    function showToast(msg) {
+      const toast = document.getElementById('toast');
+      toast.textContent = msg;
+      toast.classList.add('show');
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(() => toast.classList.remove('show'), 2000);
+    }
+
+    function copyHex(hex, blockEl) {
+      const text = hex;
+      const doFlash = () => {
+        blockEl.classList.add('flash');
+        setTimeout(() => blockEl.classList.remove('flash'), 800);
+        showToast(`Copied ${hex}`);
+      };
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(doFlash).catch(() => fallbackCopy(text, doFlash));
+      } else {
+        fallbackCopy(text, doFlash);
+      }
+    }
+
+    function fallbackCopy(text, cb) {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.cssText = 'position:fixed;opacity:0;top:0;left:0';
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand('copy'); } catch (_) { /* ignore */ }
+      document.body.removeChild(ta);
+      cb();
+    }
+
+    /* ────────────────────────────────────────
+       Events
+    ──────────────────────────────────────── */
+
+    // Generate button
+    document.getElementById('generateBtn').addEventListener('click', () => {
+      const mode = document.getElementById('harmonySelect').value;
+      palette = generatePalette(palette, mode);
+      render();
+    });
+
+    // Harmony select: auto-generate on change
+    document.getElementById('harmonySelect').addEventListener('change', () => {
+      // Only regenerate unlocked colors
+      const mode = document.getElementById('harmonySelect').value;
+      palette = generatePalette(palette, mode);
+      render();
+    });
+
+    // Delegate: copy on color-block click / Enter/Space
+    document.getElementById('palette').addEventListener('click', e => {
+      const block = e.target.closest('.color-block');
+      if (block) {
+        const idx = parseInt(block.dataset.index, 10);
+        copyHex(palette[idx].hex, block);
+        return;
+      }
+      const lockBtn = e.target.closest('.btn-lock');
+      if (lockBtn) {
+        const idx = parseInt(lockBtn.dataset.index, 10);
+        palette[idx].locked = !palette[idx].locked;
+        render();
+      }
+    });
+
+    // Keyboard accessibility for color blocks
+    document.getElementById('palette').addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        const block = e.target.closest('.color-block');
+        if (block) {
+          e.preventDefault();
+          const idx = parseInt(block.dataset.index, 10);
+          copyHex(palette[idx].hex, block);
+        }
+      }
+    });
+
+    /* ────────────────────────────────────────
+       Init: generate first palette on load
+    ──────────────────────────────────────── */
+    palette = generatePalette([], 'analogous');
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `public/color-palette.html` — a self-contained color palette generator page
- Generates 5 harmonious colors using Analogous, Complementary, Triadic, Split-Complementary, or Random harmony modes
- Each color card displays hex code and RGB values
- Click any color swatch to copy hex code to clipboard (with flash feedback + toast)
- Lock/unlock individual colors to preserve them while regenerating others
- Responsive grid layout: 5 columns → 2 columns → 1 column
- Matches the dark theme and code style of existing public pages

## Test plan
- [x] Tests pass locally (`pnpm test` — 29/29 passing)
- [x] Quality gate passes (`pnpm check` — format, typecheck, lint all clear)
- [x] Generates 5 colors with hex/RGB display
- [x] Copy-to-clipboard works (with clipboard API + execCommand fallback)
- [x] Lock/unlock individual colors while regenerating others

Fixes #41