### PR TITLE
feat(api): add /echo endpoint for debugging (fixes #46)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import {
 } from "./store.js";
 import { healthCheck } from "./health.js";
 import { getStats } from "./stats.js";
+import { echoHandler } from "./echo.js";
 
 export const app: Express = express();
 app.use(express.json());
@@ -17,6 +18,10 @@ app.get("/health", healthCheck);
 
 // Stats
 app.get("/stats", getStats);
+
+// Echo (debugging)
+app.get("/echo", echoHandler);
+app.post("/echo", echoHandler);
 
 // List all todos
 app.get("/todos", (_req, res) => {

--- a/src/echo.test.ts
+++ b/src/echo.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { echoHandler } from "./echo.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.get("/echo", echoHandler);
+  app.post("/echo", echoHandler);
+  return app;
+}
+
+describe("GET /echo", () => {
+  it("returns method, path, and timestamp", async () => {
+    const res = await request(createApp()).get("/echo");
+    expect(res.status).toBe(200);
+    expect(res.body.method).toBe("GET");
+    expect(res.body.path).toBe("/echo");
+    expect(typeof res.body.timestamp).toBe("string");
+  });
+
+  it("returns headers", async () => {
+    const res = await request(createApp())
+      .get("/echo")
+      .set("x-custom-header", "test-value");
+    expect(res.body.headers).toHaveProperty("x-custom-header", "test-value");
+  });
+
+  it("returns query params", async () => {
+    const res = await request(createApp()).get("/echo?foo=bar&baz=qux");
+    expect(res.body.query).toEqual({ foo: "bar", baz: "qux" });
+  });
+
+  it("does not include body field", async () => {
+    const res = await request(createApp()).get("/echo");
+    expect(res.body).not.toHaveProperty("body");
+  });
+});
+
+describe("POST /echo", () => {
+  it("returns method, path, and timestamp", async () => {
+    const res = await request(createApp())
+      .post("/echo")
+      .send({ hello: "world" });
+    expect(res.status).toBe(200);
+    expect(res.body.method).toBe("POST");
+    expect(res.body.path).toBe("/echo");
+    expect(typeof res.body.timestamp).toBe("string");
+  });
+
+  it("returns headers", async () => {
+    const res = await request(createApp())
+      .post("/echo")
+      .set("x-custom-header", "test-value")
+      .send({});
+    expect(res.body.headers).toHaveProperty("x-custom-header", "test-value");
+  });
+
+  it("returns request body", async () => {
+    const res = await request(createApp())
+      .post("/echo")
+      .send({ key: "value", num: 42 });
+    expect(res.body.body).toEqual({ key: "value", num: 42 });
+  });
+
+  it("does not include query field", async () => {
+    const res = await request(createApp()).post("/echo").send({});
+    expect(res.body).not.toHaveProperty("query");
+  });
+});

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from "express";
+
+export interface EchoResponse {
+  method: string;
+  path: string;
+  timestamp: string;
+  headers: Record<string, string | string[] | undefined>;
+  query?: Record<string, string | string[] | undefined>;
+  body?: unknown;
+}
+
+export function echoHandler(req: Request, res: Response): void {
+  const base: EchoResponse = {
+    method: req.method,
+    path: req.path,
+    timestamp: new Date().toISOString(),
+    headers: req.headers as Record<string, string | string[] | undefined>,
+  };
+
+  if (req.method === "GET") {
+    res.json({
+      ...base,
+      query: req.query as Record<string, string | string[] | undefined>,
+    });
+  } else {
+    res.json({
+      ...base,
+      body: req.body,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Added `GET /echo` endpoint that returns request headers, query params, method, path, and timestamp
- Added `POST /echo` endpoint that returns request headers, body, method, path, and timestamp
- Registered both routes in `src/app.ts`

## Test plan
- [x] `GET /echo` returns headers and query params
- [x] `POST /echo` returns headers and body
- [x] Both endpoints include `method`, `path`, and `timestamp` fields
- [x] Tests cover both methods (8 test cases)
- [x] `pnpm check && pnpm test` passes (37 tests total)

Fixes #46