### PR TITLE
fix(health): enforce ISO 8601 timestamp format (fixes #45)

### DIFF
--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -23,4 +23,12 @@ describe("GET /health", () => {
     expect(typeof res.body.uptime).toBe("number");
     expect(typeof res.body.timestamp).toBe("string");
   });
+
+  it("returns timestamp in ISO 8601 format", async () => {
+    const res = await request(createApp()).get("/health");
+    const ts = res.body.timestamp as string;
+    // ISO 8601: YYYY-MM-DDTHH:mm:ss.sssZ
+    expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(new Date(ts).toISOString()).toBe(ts);
+  });
 });


### PR DESCRIPTION
## Summary
- The `/health` endpoint already returns `timestamp` via `new Date().toISOString()` (ISO 8601 format)
- The existing test only verified `typeof timestamp === 'string'`, not the actual format
- Added an explicit ISO 8601 regex test and `new Date().toISOString()` round-trip check to enforce the requirement and prevent future regressions

## Test plan
- [x] New test `returns timestamp in ISO 8601 format` verifies format matches `YYYY-MM-DDTHH:mm:ss.sssZ`
- [x] All 30 tests pass
- [x] Quality gate passes (`pnpm check && pnpm test`)

Fixes #45